### PR TITLE
Updated node-influx library version

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ Collector.prototype.flush = function(callback) {
 // @param [Object] fields the data
 // @param [Object] tags the tags (optional)
 Collector.prototype.collect = function(seriesName, fields, tags) {
-    if (typeof fields === 'number') {
+    if (typeof fields !== 'object') {
       fields = { value: fields }
     }
     var point = {

--- a/index.js
+++ b/index.js
@@ -124,11 +124,15 @@ Collector.prototype.flush = function(callback) {
 // @param [Object] value the data
 // @param [Object] tags the tags (optional)
 Collector.prototype.collect = function(seriesName, value, tags) {
+    if (typeof value === 'number') {
+      value = { value: value }
+    }
     var point = {
       measurement: seriesName,
       tags: tags,
-      fields: { value: value}
+      fields: value
     }
+
     if (this._instant_flush) {
         this._flushPoints([point]);
     } else {

--- a/index.js
+++ b/index.js
@@ -121,16 +121,16 @@ Collector.prototype.flush = function(callback) {
 };
 
 // collect a data point (or object)
-// @param [Object] value the data
+// @param [Object] fields the data
 // @param [Object] tags the tags (optional)
-Collector.prototype.collect = function(seriesName, value, tags) {
-    if (typeof value === 'number') {
-      value = { value: value }
+Collector.prototype.collect = function(seriesName, fields, tags) {
+    if (typeof fields === 'number') {
+      fields = { value: fields }
     }
     var point = {
       measurement: seriesName,
       tags: tags,
-      fields: value
+      fields: fields
     }
 
     if (this._instant_flush) {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,8 @@
   },
   "homepage": "https://github.com/defunctzombie/node-influx-collector",
   "devDependencies": {
-    "mock-udp": "0.1.1",
     "mocha": "2.0.1",
-    "nock": "2.9.1"
+    "simple-mock": "0.7.3"
   },
   "dependencies": {
     "influx": "5.0.6"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "nock": "2.9.1"
   },
   "dependencies": {
-    "influx": "4.0.1",
-    "influx-udp": "heap/node-influx-udp#heap"
+    "influx": "5.0.6"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,29 @@ describe('Influx Collector', function() {
       done();
   });
 
-  it('should collect a single data point', function(done) {
+  it('should collect a single data point with a primative value', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL);
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
+
+      statsCollector.collect('series-name', 35);
+      statsCollector.flush();
+
+      assert.equal(writePointsSpy.callCount, 1);
+      var writeArgs = [
+        [
+          {
+            measurement: 'series-name',
+            tags: undefined,
+            fields: {value: 35}
+          }
+        ],
+        {precision: undefined}
+      ];
+      assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
+      done();
+  });
+
+  it('should collect a single data point with an object value', function(done) {
       var statsCollector = Collector(COLLECTOR_URL);
       var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,196 +1,178 @@
-
-var nock = require('nock');
-var mock_udp = require('mock-udp');
 var assert = require('assert');
+var simple = require('simple-mock')
 
 var Collector = require('../');
 
-suite('influx-collector');
-
 var COLLECTOR_URL = 'http://user:password@example.com:8086/test-db';
-var UDP_COLLECTOR_URL = 'udp://user:password@example.com:8086/db-defined-in-server-config';
 
-test('should create a collector', function(done) {
-    Collector(COLLECTOR_URL);
-    done();
-});
+describe('Influx Collector', function() {
+  it('should create a collector', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL);
+      done();
+  });
 
-test('should collect a single data point', function(done) {
-    var stats = Collector(COLLECTOR_URL);
+  it('should collect a single data point', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL);
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
 
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 'ms', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        assert.equal(request_body, 'series foo=34');
-    })
+      statsCollector.collect('series-name', {foo: 34.0});
+      statsCollector.flush();
 
-    stats.collect('series', { foo: 34.0 })
+      assert.equal(writePointsSpy.callCount, 1);
+      var writeArgs = [
+        [
+          {
+            measurement: 'series-name',
+            tags: undefined,
+            fields: {foo: 34}
+          }
+        ],
+        {precision: undefined}
+      ];
+      assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
+      done();
+  });
 
-    stats.flush();
-    setTimeout(function() {
-        req.done();
+  it('should collect a single data point with tags', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL);
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
+
+      statsCollector.collect('series-name', {foo: 34.0}, {host: 'cat'});
+      statsCollector.flush();
+
+      assert.equal(writePointsSpy.callCount, 1);
+      var writeArgs = [
+        [
+          {
+            measurement: 'series-name',
+            tags: {host: 'cat'},
+            fields: {foo: 34}
+          }
+        ],
+        {precision: undefined}
+      ];
+      assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
+      done();
+  });
+
+  it('should collect multiple data points', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL);
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
+
+      statsCollector.collect('series-name', {bar: 'cat', foo: 34.0});
+      statsCollector.collect('series-name2', {foo: 10.2, bar: 'dog'});
+      statsCollector.flush();
+
+      assert.equal(writePointsSpy.callCount, 1);
+      var writeArgs = [
+        [
+          {
+            measurement: 'series-name',
+            tags: undefined,
+            fields: {bar: 'cat', foo: 34.0}
+          },
+          {
+            measurement: 'series-name2',
+            tags: undefined,
+            fields: {bar: 'dog', foo: 10.2}
+          }
+        ],
+        {precision: undefined}
+      ];
+      assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
+      done();
+  });
+
+  it('should support instantFlush', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL + '?instantFlush=yes');
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
+
+      statsCollector.collect('series-name', {foo: 34.0});
+
+      assert.equal(writePointsSpy.callCount, 1);
+      var writeArgs = [
+        [
+          {
+            measurement: 'series-name',
+            tags: undefined,
+            fields: {foo: 34.0}
+          }
+        ],
+        {precision: undefined}
+      ];
+      assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
+      done();
+  });
+
+  it('should support a custom flushInterval', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL + '?flushInterval=500');
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
+
+      statsCollector.collect('series-name', {foo: 34.0});
+
+      assert.equal(writePointsSpy.callCount, 0);
+      setTimeout(function() {
+        assert.equal(writePointsSpy.callCount, 1);
+        var writeArgs = [
+          [
+            {
+              measurement: 'series-name',
+              tags: undefined,
+              fields: {foo: 34.0}
+            }
+          ],
+          {precision: undefined}
+        ];
+        assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
         done();
-    }, 100);
-});
+      }, 600);
+  });
 
-test('should collect a single data point via UDP', function(done) {
-    var stats = Collector(UDP_COLLECTOR_URL);
+  it('should support a autoFlush=no', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL + '?flushInterval=500&autoFlush=no');
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
 
-    var scope = mock_udp('example.com:8086');
+      statsCollector.collect('series-name', {foo: 34.0});
 
-    stats.collect(
-        'series-name',
-        {key: "val", key2: "val2"},
-        {tkey1: "tval1", tkey2: "tval2"}
-    );
-    stats.flush();
-
-    assert.deepEqual(
-        scope.buffer.toString(),
-        "series-name,tkey1=tval1,tkey2=tval2 key=val,key2=val2"
-    );
-    scope.done();
-    done();
-});
-
-test('should collect a single data point with tags', function(done) {
-    var stats = Collector(COLLECTOR_URL);
-
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 'ms', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        assert.equal(request_body, 'series-name,host=cat foo=34');
-    })
-
-    stats.collect('series-name', { foo: 34.0 }, { host: 'cat' })
-
-    stats.flush();
-    setTimeout(function() {
-        req.done();
+      assert.equal(writePointsSpy.callCount, 0);
+      setTimeout(function() {
+        assert.equal(writePointsSpy.callCount, 0);
+        statsCollector.flush();
+        assert.equal(writePointsSpy.callCount, 1);
+        var writeArgs = [
+          [
+            {
+              measurement: 'series-name',
+              tags: undefined,
+              fields: {foo: 34.0}
+            }
+          ],
+          {precision: undefined}
+        ];
+        assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
         done();
-    }, 100);
+      }, 600);
+  });
 
-});
+  it('should support time_precision', function(done) {
+      var statsCollector = Collector(COLLECTOR_URL + '?time_precision=s');
+      var writePointsSpy = simple.mock(statsCollector._client, 'writePoints');
 
-test('should collect multiple data points', function(done) {
-    var stats = Collector(COLLECTOR_URL);
+      statsCollector.collect('series-name', {time: 1416512521, foo: 34.0});
+      statsCollector.flush();
 
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*\nseries-name foo=10.2,bar="dog"')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 'ms', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        var expected = 'series-name bar="cat",foo=34\nseries-name foo=10.2,bar="dog"';
-        assert.equal(request_body, expected);
-    });
-
-    stats.collect('series-name', { bar: 'cat', foo: 34.0 });
-    stats.collect('series-name', { foo: 10.2, bar: 'dog' });
-
-    stats.flush();
-    setTimeout(function() {
-        req.done();
-        done();
-    }, 100);
-});
-
-test('should support instantFlush', function(done) {
-    var stats = Collector(COLLECTOR_URL + '?instantFlush=yes');
-
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 'ms', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        assert.equal(request_body, 'series-name foo=34');
-    });
-
-    stats.collect('series-name', { foo: 34.0 });
-
-    setTimeout(function() {
-        req.done();
-        done();
-    }, 100);
-});
-
-test('should support a custom flushInterval', function(done) {
-    var stats = Collector(COLLECTOR_URL + '?flushInterval=500');
-
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 'ms', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        assert.equal(request_body, 'series foo=34');
-    });
-
-    stats.collect('series', { foo: 34.0 })
-
-    setTimeout(function() {
-        req.done();
-        done();
-    }, 1000);
-});
-
-test('should support a autoFlush=no', function(done) {
-    var stats = Collector(COLLECTOR_URL + '?flushInterval=500&autoFlush=no');
-
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 'ms', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        assert.equal(request_body, 'series foo=34');
-    });
-
-    stats.collect('series', { foo: 34.0 })
-
-    setTimeout(function() {
-        assert(req.isDone() == false);
-
-        stats.flush();
-
-        setTimeout(function() {
-            req.done();
-            done();
-        }, 200);
-    }, 1000);
-});
-
-test('should support time_precision', function(done) {
-    var stats = Collector(COLLECTOR_URL + '?time_precision=s');
-
-    var req = nock('http://example.com:8086')
-    .filteringRequestBody(/.*/, function(body) {
-        return '*';
-    })
-    .post('/write', '*')
-    .query({db: 'test-db', u: 'user', p: 'password', precision: 's', database: 'test-db' })
-    .reply(200, function(uri, request_body) {
-        assert.equal(request_body, 'series foo=34 1416512521');
-    });
-
-    stats.collect('series', { time: 1416512521, foo: 34.0 });
-
-    stats.flush();
-    setTimeout(function() {
-        req.done();
-        done();
-    }, 200);
+      assert.equal(writePointsSpy.callCount, 1);
+      var writeArgs = [
+        [
+          {
+            measurement: 'series-name',
+            tags: undefined,
+            fields: {time: 1416512521, foo: 34.0}
+          }
+        ],
+        {precision: 's'}
+      ];
+      assert.deepEqual(writePointsSpy.calls[0].args, writeArgs);
+      done();
+  });
 });


### PR DESCRIPTION
I opted to remove `influx_udp` because the new `node-influx` lib uses a different format for the points (https://node-influx.github.io/typedef/index.html#static-typedef-IPoint). Points now take the measurement/series name, so there's no need to accumulate and flush by series. Keeping both would leave a looooot of cruft.