### PR TITLE
Pass in timestamp to underlying Influx library.

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,8 @@ Collector.prototype.collect = function(seriesName, fields, tags) {
     var point = {
       measurement: seriesName,
       tags: tags,
-      fields: fields
+      fields: fields,
+      timestamp: fields.time
     }
 
     if (this._instant_flush) {


### PR DESCRIPTION
Previously we would pass in `time` as a field to Influx and the library we were
using would use that as the value of the time column. This commit adds that
behavior with the current influx library we are using.